### PR TITLE
fix header size for iphone 5S

### DIFF
--- a/index.css
+++ b/index.css
@@ -207,7 +207,7 @@ body {
 /* Extra small devices (phones, 599px and down) */
 @media only screen and (max-width: 599px) {
   h1 {
-    font-size: 2.25rem;
+    font-size: 2rem;
   }
   #quote-box,
   #instructions {
@@ -228,7 +228,7 @@ body {
 /* Small devices (portrait tablets and large phones, 600px and up) */
 @media only screen and (min-width: 600px) {
   h1 {
-    font-size: 2.75rem;
+    font-size: 2.5rem;
   }
   #quote-box,
   #instructions {


### PR DESCRIPTION
Header wrapped on iPhone 5s. Dropped font size down to 2rem.